### PR TITLE
docs: add a small note on dependency management for PYTHONPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ To deploy your function please refer to our official documentation.
 
 No, this framework does not affect deployment or performance.
 
+**How can I use my packaged dependencies?**
+
+When deploying Python functions, your dependencies must be bundled in a `package` folder at the root of your project. For local testing, you can set `PYTHONPATH=$(pwd)/package` to make your dependencies available. This can be useful to avoid packaging your dependencies in multiple locations.
+
+Please note that this does not work for native dependencies as the Scaleway Python runtime is different from your local machine.
+
 ## 🎓 Contributing
 
 We welcome all contributions to our open-source projects, please see our [contributing guidelines](./.github/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

**_What's changed?_**

Added a small note for dependencies management following a discussion with an internal user

**_Why do we need this?_**

Informs of an unexpected difference between local testing framework and Scaleway runtime

**_How have you tested it?_**

N/A

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
