### PR TITLE
fix(ci): fix bad use of poetry groups + update to Python 3.12 in publish CI

### DIFF
--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,5 +1,8 @@
+---
 name: Set up poetry
+
 description: Install poetry and python dependencies
+
 inputs:
   groups:
     description: "Poetry dependencies groups."
@@ -7,6 +10,7 @@ inputs:
   python-version:
     description: "Python version."
     required: true
+
 runs:
   using: "composite"
   steps:
@@ -29,9 +33,9 @@ runs:
       uses: actions/cache@v3
       with:
         path: .venv
-        key: venv-${{ inputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-${{ inputs.groups }}
+        key: venv-${{ inputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
     - name: Install Poetry dependencies
       shell: bash
-      run: poetry install --no-interaction --no-root --only main,${{ inputs.groups }}
+      run: poetry install --no-interaction --no-root --only ${{ inputs.groups }}
       if: steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
         with:
-          groups: test
+          groups: main,test
           python-version: ${{ matrix.python-version }}
 
       - name: Print versions

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,5 +1,4 @@
 ---
-
 name: python-publish
 
 on:
@@ -15,17 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up python 3.11
+      - name: Set up python 3.12
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.12"
 
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
         with:
-          groups: ''  # will only install the main group
-          python-version: '3.11'
+          groups: main
+          python-version: "3.12"
 
       - name: Publish package
         run: poetry publish --build


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Stop using "main" as the default group in the custom "setup-poetry" action

**_Why do we need this?_**

- Fix the CI, which is blocking the deployment of release `v2.0.1`

- I previously relied on a strange behavior, when parsing flags which were lists of strings, poetry would ignore if an element was empty. It now considers this a valid input, so when passing "--only main,", it identifies two groups, `main` and ``. The latter is not a valid group, so it fails.
- TBH I'm not sure why I chose this approach as opposed to just using `--with`, I think there was a specific case where we only needed a non-main dependency group, so I chose this. 

**_How have you tested it?_**

- Can't be tested via the CI, but this fix is taken from: https://github.com/scaleway/dagster-scaleway/blob/main/.github/workflows/publish.yml

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
