### PR TITLE
Fix ValueError when decoding non-unicode body

### DIFF
--- a/scaleway_functions_python/local/event.py
+++ b/scaleway_functions_python/local/event.py
@@ -41,6 +41,6 @@ def format_http_event(request: "Request") -> "Event":
     try:
         b64decode(body, validate=True).decode("utf-8")
         event["isBase64Encoded"] = True
-    except (binascii.Error, UnicodeDecodeError):
+    except (binascii.Error, UnicodeDecodeError, ValueError):
         pass
     return event


### PR DESCRIPTION
## Summary

The PR fixes a bug in parsing non-unicode body.

**_What's changed?_**
The  `ValueError` was added as one of the exceptions caught.

**_Why do we need this?_**
It fixes #73 issue.

**_How have you tested it?_**
With the attached unit tests.

## Checklist

- [x] I have reviewed this myself
- [x] There is a unit test covering every change in this PR
- [x] I have updated the relevant documentation

## Details
