### PR TITLE
chore: add compatibility with Python 3.13

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,21 +10,21 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up python 3.12
+      - name: Set up python 3.13
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Set up Poetry
         uses: ./.github/actions/setup-poetry
         with:
           groups: main
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Publish package
         run: poetry publish --build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  python: python3.12
+  python: python3.13
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 <!-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## [0.2.3] - 2025-04-14
+
+### Changed
+
+- Add compatibility with Python 3.13
+
 ## [0.2.2] - 2024-11-27
 
 ### Fixed

--- a/poetry.lock
+++ b/poetry.lock
@@ -332,7 +332,7 @@ description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version < \"3.10\""
+markers = "python_version == \"3.9\""
 files = [
     {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
     {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
@@ -850,7 +850,7 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version < \"3.10\""
+markers = "python_version == \"3.9\""
 files = [
     {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
     {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
@@ -866,5 +866,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9, <3.13"
-content-hash = "bce96ceca96df4203abf0fb256dd45b1ec1e3b2df2c229eba6f89017f0783061"
+python-versions = ">=3.9, <3.14"
+content-hash = "a4e1f1ade585009122006199e23db766b44e91b2a284bcf308506487bbaf611f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scaleway-functions-python"
-version = "0.2.2"
+version = "0.2.3"
 description = "Utilities for testing your Python handlers for Scaleway Serverless Functions."
 authors = ["Scaleway Serverless Team <opensource@scaleway.com>"]
 
@@ -26,12 +26,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 include = ["CHANGELOG.md"]
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.13"
+python = ">=3.9, <3.14"
 flask = ">=2.2.2,<4.0.0"
 typing-extensions = { version = "^4.4.0", python = "<3.11" }
 


### PR DESCRIPTION
**_What's changed?_**

- This pull request includes updates to add compatibility with Python 3.13 across various configuration files and documentation. The most important changes include updating the Python version in GitHub workflows, the pre-commit configuration, and the project metadata.
- Bump version to 0.2.3

**_Why do we need this?_**

We've released Python 3.13 as a runtime on Scaleway Serverless Functions.

**_How have you tested it?_**

Pipeline passes :white_check_mark: 

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [x] I have updated the relevant documentation

## Details
